### PR TITLE
Bit cleaner 007 in Clojure

### DIFF
--- a/Problem007/Clojure/solution_2.clj
+++ b/Problem007/Clojure/solution_2.clj
@@ -1,0 +1,17 @@
+(defn prime? [n]
+  (= 2 (reduce +
+               (for [i (range 1 (inc n))]
+                 (if (= 0 (rem n i)) 1 0)))))
+
+(defn next-prime
+  [n]
+  (loop [candidate n]
+    (if (is-prime candidate)
+      candidate
+      (recur (+ candidate 1)))))
+
+(defn prime-seq
+  ([] (prime-seq 2))
+  ([n] (cons n (lazy-seq (prime-seq (next-prime (+' 1 n )))))))
+
+(str (last (take 10001 (prime-seq))))


### PR DESCRIPTION
just simplifying prime? func. 

with  ```(take 10001 (prime-seq))```

solution_1.clj
![sol_1](https://cloud.githubusercontent.com/assets/5731508/18233365/00da5ce8-72bc-11e6-8a00-f9b2d343ae5e.png)

solution_2.clj
![sol_2](https://cloud.githubusercontent.com/assets/5731508/18233367/05ce6474-72bc-11e6-800a-c08186f32ea9.png)
