### PR TITLE
Fix C language build support on stats.py

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,6 @@ services:
                               --s c++
                               --s bash
                               --s clojure
+                              --s c
     volumes:
       - .:/code

--- a/stats.py
+++ b/stats.py
@@ -73,7 +73,7 @@ class Build(Checker):
     fout = "compiled.out"
 
     def compile(self):
-        args = self.compiler + [self.path, "-o", self.output]
+        args = [self.compiler[0], self.path, "-o", self.output] + self.compiler[1:]
         program = subprocess.Popen(args, stdout=subprocess.PIPE)
         return program.wait() == 0
 


### PR DESCRIPTION
Now we can test C source-code on travis system without any problem. Should fix #13.