### PR TITLE
Split docker-compose runner into async and sync services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
   - docker
 
 script:
-  - docker-compose up --abort-on-container-exit
+  - docker-compose run async --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@ RUN apt-get update \
 RUN apt-get install -y software-properties-common \
                        python-software-properties \
                        python3-pip \
-                       wget 
+                       wget
 ADD requirements.txt .
 RUN apt-get install cython -y
 RUN pip3 install -r requirements.txt
 # set locale
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # language deps

--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@ Compilation of some solutions of the challenges existent in the website www.proj
 
 ## Test
 
-You can now test the algoritms just using our Docker image hosted on `destructhub/project_euler` just calling:
-`docker-compose up`. On the end of execution, will be print a tabular-like structure with information about problem,
+You can now test the algoritms just using on our Docker image hosted on
+`destructhub/project_euler` just calling: `docker-compose run async`
+or `docker-compose run sync`.  Assuming of course that you have a
+`docker` installation with `docker-compose`.  On the end of execution,
+will be print a tabular-like structure with information about problem,
 language, time execution and if the answer is correct.
+
+The asynchronous build is written in Elixir, the synchronous version
+is written in Python. You can look on both systems at `stats.exs` and `stats.py`.
 
 ## Status
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,38 @@
 version: "2"
 
 services:
-  runner:
+  async:
     image: destructhub/project_euler
-    command: elixir --no-halt stats.exs -s python
-                                        -s commonlisp
-                                        -s ruby
-                                        -s haskell
-                                        -s go
-                                        -s php
-                                        -s elixir
-                                        -s lua
-                                        -s c++
-                                        -s bash
-                                        -s clojure
-                                        -s c
-                                        --quiet
+    entrypoint: elixir --no-halt stats.exs -s python
+                                           -s commonlisp
+                                           -s ruby
+                                           -s haskell
+                                           -s go
+                                           -s php
+                                           -s elixir
+                                           -s lua
+                                           -s c++
+                                           -s bash
+                                           -s clojure
+                                           -s c
     environment:
       STATS_POOL_SIZE: #{STATS_POOL_SIZE}
+    volumes:
+      - .:/code
+
+  sync:
+    image: destructhub/project_euler
+    command: python3 stats.py --build -s python
+                                      -s commonlisp
+                                      -s ruby
+                                      -s haskell
+                                      -s go
+                                      -s php
+                                      -s elixir
+                                      -s lua
+                                      -s c++
+                                      -s bash
+                                      -s clojure
+                                      -s c
     volumes:
       - .:/code


### PR DESCRIPTION
As well, now the async version should show spinners as default and
silent them only passing the `--quiet` arg like: `docker-compose run
async --quiet`

So the overall usage for now is:
```bash
docker-compose run sync # run python stats
docker-compose run async # run elixir stats with spinners
docker-compose run async --quiet # run elixir stats but no spinners
```