### PR TITLE
[test] Build all solutions async on push master event triggered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
 
 script:
   - sudo chmod +x ./test
-  - docker-compose run -e "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST" diff-sync
+  - docker-compose run -e "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST" -e "TRAVIS_BRANCH=$TRAVIS_BRANCH" diff-sync

--- a/test
+++ b/test
@@ -2,9 +2,13 @@
 
 
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    # Cancel build if travis is building pushed version
-    echo "Skipped this build"
-    exit 0
+    if [ "$TRAVIS_BRANCH" = "master" ]; then
+        docker-compose run async
+        exit $?
+    else # Cancel build if travis is building pushed version
+        echo "Skipped this build"
+        exit 0
+    fi
 fi
 
 # only return the arguments which are files that exists on the filesystem


### PR DESCRIPTION
This will ensure that we always have code running ok on master and
no bug happened with the differential build system or something like
that. This is good too because we are using the two solutions here:

+ on differential build on PR we use the sync version written
  in Python (stats.py)
+ on push master events which build all solutions we use the async
version written in Elixir (stats.exs)

Should fix #144.