### PR TITLE
[test] Recursive docker-compose doesn't makes any sense

### DIFF
--- a/test
+++ b/test
@@ -3,7 +3,18 @@
 
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     if [ "$TRAVIS_BRANCH" = "master" ]; then
-        docker-compose run async
+        elixir --no-halt stats.exs -s python \
+                                   -s commonlisp \
+                                   -s ruby \
+                                   -s haskell \
+                                   -s go \
+                                   -s php \
+                                   -s elixir \
+                                   -s lua \
+                                   -s c++ \
+                                   -s bash \
+                                   -s clojure \
+                                   -s c
         exit $?
     else # Cancel build if travis is building pushed version
         echo "Skipped this build"


### PR DESCRIPTION
The old solutions doesn't works inside of docker-compose
since we don't have a docker-compose inside of docker container.

Probably will be better later moving this handling of TRAVIS stuff of
`test` to `.travis.yml`, but this get the things done for now.