### PR TITLE
[test] Add -q (--quiet) flag to stats.exs execution

### DIFF
--- a/test
+++ b/test
@@ -14,7 +14,8 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
                                    -s c++ \
                                    -s bash \
                                    -s clojure \
-                                   -s c
+                                   -s c \
+                                   -q
         exit $?
     else # Cancel build if travis is building pushed version
         echo "Skipped this build"


### PR DESCRIPTION
This will avoid a lot of spinners print on travis build, as
we're doing earlier on old .travis.yml file.

The problem: https://travis-ci.org/DestructHub/ProjectEuler/builds/302960212