### PR TITLE
[test] Delegate status exit from test and stats.py

### DIFF
--- a/test
+++ b/test
@@ -65,8 +65,10 @@ function main () {
     elif [ "$mode" = "sync" ]; then
         if [ "$target" = "diff" ]; then
             build_commited
+            status=$?
         elif [ "$target" = "staged" ]; then
             build_staged
+            status=$?
         fi
     else
         echo "Usage : $0 [sync|async] [diff|staged]"


### PR DESCRIPTION
This should ensure that the TravisCI fails when stats.py fails.

Example.: https://travis-ci.org/DestructHub/ProjectEuler/builds/303403163?utm_source=github_status&utm_medium=notification