### PR TITLE
Stats.py updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ draft
 
 # My emacs org-mode file (leorog)
 todo.org
+
+# Virtualenv
+venv

--- a/Problem001/Go/solution_1.go
+++ b/Problem001/Go/solution_1.go
@@ -13,5 +13,6 @@ func main() {
 			sum += i
 		}
 	}
+    
 	fmt.Println(sum)
 }

--- a/Problem001/Go/solution_1.go
+++ b/Problem001/Go/solution_1.go
@@ -13,6 +13,5 @@ func main() {
 			sum += i
 		}
 	}
-
 	fmt.Println(sum)
 }

--- a/Problem001/Go/solution_1.go
+++ b/Problem001/Go/solution_1.go
@@ -13,6 +13,6 @@ func main() {
 			sum += i
 		}
 	}
-    
+
 	fmt.Println(sum)
 }

--- a/Problem002/Go/solution_1.go
+++ b/Problem002/Go/solution_1.go
@@ -18,6 +18,6 @@ func p2(n int) int {
 }
 
 func main(){
-    time.Sleep(3000 * time.Millisecond)
+    time.Sleep(61 * 1000 * time.Millisecond)
 	fmt.Print(p2(4000000))
 }

--- a/Problem002/Go/solution_1.go
+++ b/Problem002/Go/solution_1.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+func p2(n int) int {
+	sum, a, b, c := 0, 1, 1, 2 // c=a+b
+	for c < n {
+	        if n % 2 == 0 {
+	  	        sum += c
+	        }
+		a = b + c
+		b = c + a
+		c = a + b
+	}
+	return sum
+}
+
+func main(){
+	fmt.Print(p2(4000000))
+}

--- a/Problem002/Go/solution_1.go
+++ b/Problem002/Go/solution_1.go
@@ -1,7 +1,6 @@
 package main
 
 import "fmt"
-import "time"
 
 func p2(n int) int {
 	sum, a, b, c := 0, 1, 1, 2 // c = a + b
@@ -13,11 +12,9 @@ func p2(n int) int {
 		b = c + a
 		c = a + b
 	}
-
 	return sum
 }
 
 func main(){
-    time.Sleep(61 * 1000 * time.Millisecond)
-	fmt.Print(p2(4000000))
+    	fmt.Println(p2(4000000))
 }

--- a/Problem002/Go/solution_1.go
+++ b/Problem002/Go/solution_1.go
@@ -1,9 +1,10 @@
 package main
 
 import "fmt"
+import "time"
 
 func p2(n int) int {
-	sum, a, b, c := 0, 1, 1, 2 // c=a+b
+	sum, a, b, c := 0, 1, 1, 2 // c = a + b
 	for c < n {
 	        if n % 2 == 0 {
 	  	        sum += c
@@ -12,9 +13,11 @@ func p2(n int) int {
 		b = c + a
 		c = a + b
 	}
+
 	return sum
 }
 
 func main(){
+    time.Sleep(3000 * time.Millisecond)
 	fmt.Print(p2(4000000))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,6 @@ services:
       - .:/code
   diff-sync:
     image: destructhub/project_euler
-    command: bash test
+    command: ./test
     volumes:
       - .:/code

--- a/stats.py
+++ b/stats.py
@@ -586,8 +586,7 @@ def build_result(df, ignore_errors=False, blame=False, only=()):
             correct = False
             control.time = time.time()
             answer, t = execute_builder(b)
-            outtimed = t == -1
-
+            outtimed = answer == "TIMEOUT"
             if (not outtimed) and problem in hashes:
                 answer_hash = digest_answer(answer)
                 correct = answer_hash == hashes[problem]

--- a/stats.py
+++ b/stats.py
@@ -480,9 +480,10 @@ def handle_files(files):
     for f in files:
         if f.count("/") == 2:
             solutions.append(tuple(f.split("/")))
-        elif f.count("/") == 1: 
-            continue
-        elif f.count("/") == 0: 
+        elif f.count("/") == 1 and "Problem" in f:
+            solutions += [(f, lang, solution) for lang in os.listdir(f)
+                    if lang in BUILD_SUPPORT for solution in os.listdir(f + lang)]
+        elif f.count("/") == 0:
             build_files.append(f)
     return list(filter(lambda x: is_solution(x[2]), solutions)), build_files
 
@@ -652,7 +653,7 @@ def handle_options(options):
                 "\rForced to exit: No solutions to build\nChanged_core_files : \n {}".format(
                 uncommited_core_files)
             )
-            return
+            sys.exit(1)
         tbsolutions = solutions_paths(df, from_files=uncommited_solutions)
 
     if options.all:
@@ -690,6 +691,15 @@ def handle_options(options):
 
     pd.set_option("display.max_rows", len(df))
     print(df)
+
+    count_ws = list(df["Correct"]).count(False)
+    correct_ratio = 1 - count_ws/len(df)
+
+    sys.stdout.write(
+        print("Correct solutions ratio : {0}% ".format(correct_ratio * 100))
+    )
+    if count_ws: sys.exit(1)
+
     if options.graph:
         handle_graph(df, options)
 

--- a/stats.py
+++ b/stats.py
@@ -82,9 +82,9 @@ class Execute(Checker):
             out, _ = program.communicate()
         except TimeOutController.TimeOut:
             out = b"TIMEOUT"
+            program.kill()
         finally:
             toc.cancel()
-            program.kill()
 
         if change_directory:
             os.chdir(oldpwd)

--- a/stats.py
+++ b/stats.py
@@ -508,8 +508,9 @@ def handle_files(files):
         if f.count("/") == 2:
             solutions.append(tuple(f.split("/")))
         elif f.count("/") == 1 and "Problem" in f:
-            solutions += [(f[1:], lang, solution) for lang in os.listdir(os.getcwd() + f)
-                    if lang in BUILD_SUPPORT for solution in os.listdir(os.getcwd() + f + '/' + lang)]
+            f = f.strip('/')
+            solutions += [(f, lang, solution) for lang in os.listdir(os.getcwd() + '/' + f)
+                    if lang in BUILD_SUPPORT for solution in os.listdir(os.getcwd() + '/' +  f + '/' + lang)]
         elif f.count("/") == 0:
             build_files.append(f)
     return list(filter(lambda x: is_solution(x[2]), solutions)), build_files

--- a/stats.py
+++ b/stats.py
@@ -29,7 +29,7 @@ import signal
 # #
 
 
-SOLUTION_TIMEOUT_VALUE = 1
+SOLUTION_TIMEOUT_VALUE = 30
 
 
 class TimeOutController:
@@ -508,8 +508,9 @@ def handle_files(files):
         if f.count("/") == 2:
             solutions.append(tuple(f.split("/")))
         elif f.count("/") == 1 and "Problem" in f:
-            solutions += [(f, lang, solution) for lang in os.listdir(f)
-                    if lang in BUILD_SUPPORT for solution in os.listdir(f + lang)]
+            solutions += [(f[1:], lang, solution) for lang in os.listdir(os.getcwd() + f)
+                    if lang in BUILD_SUPPORT for solution in os.listdir(os.getcwd() + f + '/' + lang)]
+            print(solutions, "hahahha")
         elif f.count("/") == 0:
             build_files.append(f)
     return list(filter(lambda x: is_solution(x[2]), solutions)), build_files

--- a/stats.py
+++ b/stats.py
@@ -510,7 +510,6 @@ def handle_files(files):
         elif f.count("/") == 1 and "Problem" in f:
             solutions += [(f[1:], lang, solution) for lang in os.listdir(os.getcwd() + f)
                     if lang in BUILD_SUPPORT for solution in os.listdir(os.getcwd() + f + '/' + lang)]
-            print(solutions, "hahahha")
         elif f.count("/") == 0:
             build_files.append(f)
     return list(filter(lambda x: is_solution(x[2]), solutions)), build_files

--- a/stats.py
+++ b/stats.py
@@ -29,7 +29,7 @@ import signal
 # #
 
 
-SOLUTION_TIMEOUT_VALUE = 30
+SOLUTION_TIMEOUT_VALUE = 60
 
 
 class TimeOutController:

--- a/stats.py
+++ b/stats.py
@@ -696,7 +696,7 @@ def handle_options(options):
     correct_ratio = 1 - count_ws/len(df)
 
     sys.stdout.write(
-        print("Correct solutions ratio : {0}% ".format(correct_ratio * 100))
+        "Correct solutions ratio : {0}% \n".format(correct_ratio * 100)
     )
     if count_ws: sys.exit(1)
 

--- a/test
+++ b/test
@@ -58,6 +58,7 @@ function main () {
     target=$2
     if [ "$mode" = "" ]; then
         build_commited
+        status=$?
     elif [ "$mode" = "async" ]; then
         #TODO: stats.exs --build --files
         echo "Not Implemented"


### PR DESCRIPTION
I tried to limit stats.py executer to 60second per solution. Here is a check list containing all the changes.

- [x] Limit solutions runtime to 60 seconds
- [x] Fails build when one bad/timeout solution appear #150 
- [x] Print stats about % success ratio at the end of the builds
- [x] add `stats.py --build --files /Problem010` support , which build all solutions in one problem. (Can someone test it manually ? ) #158 

Note: I made Golang solution for problem 2 sleep for 61 seconds to see build logs

Samples:
`./test`
```
Built Problem001/Go/solution_1.go: Answer: 233168: 0.26s
Built Problem002/Go/solution_1.go: Answer: TIMEOUT: 30.00s

      Problem Language       Time   Answer  Correct
0  Problem001       Go   0.257321   233168     True
1  Problem002       Go  60.004322  TIMEOUT    False
Correct solutions ratio : 50.0% 
```

