### PR TITLE
Improvement in Common Lisp solution of Problem003

### DIFF
--- a/Problem003/CommonLisp/solution_1.lisp
+++ b/Problem003/CommonLisp/solution_1.lisp
@@ -14,6 +14,6 @@
                         finally (return (list x c)))))
 
 (defun solution ()
-  (loop for (p f) in (factors 600851475143) maximize p))
+  (caar (last (factors 600851475143))))
 
 (format t "~a~%"(solution))


### PR DESCRIPTION
Removing unnecessary operations. ~10x more faster in a simple test~.
Maximize the factors is not necessary since the biggest factor will
be always the last in the list of factors.

We need just get the last and unpack it as (prime factor) => prime.